### PR TITLE
hack to deal with float dtype

### DIFF
--- a/predict_client/util.py
+++ b/predict_client/util.py
@@ -88,7 +88,8 @@ def make_tensor_proto(data, dtype):
         'tensor_shape': {
             'dim': dim
         },
-        'int_val': values
+        'int_val': values,
+        'float_val': values
     }
 
     dict_to_protobuf(tensor_proto_dict, tensor_proto)

--- a/predict_client/util.py
+++ b/predict_client/util.py
@@ -88,8 +88,7 @@ def make_tensor_proto(data, dtype):
         'tensor_shape': {
             'dim': dim
         },
-        'int_val': values,
-        'float_val': values
+        number_to_dtype_value[dtype]: values
     }
 
     dict_to_protobuf(tensor_proto_dict, tensor_proto)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='predict-client',
-    version='1.7.0',
+    version='1.7.1-rc-2',
     description='Client used to send grcp requests to a tfserving model',
     url='https://github.com/epigramai/tfserving_predict_client',
     author='Stian Lind Petlund',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='predict-client',
-    version='1.7.1-rc-2',
+    version='1.7.1-rc2',
     description='Client used to send grcp requests to a tfserving model',
     url='https://github.com/epigramai/tfserving_predict_client',
     author='Stian Lind Petlund',


### PR DESCRIPTION
Not 100% sure what is going on, but without this, if `'in_tensor_dtype': 'DT_FLOAT'`, then input that is sent in is silently converted to zeroes. Not sure whether additional keys should be added and whether they should be set depending on the `dtype`.